### PR TITLE
Update field 8 name in info.header.dat to depth.interval.for.smoothing

### DIFF
--- a/R/process.cops.R
+++ b/R/process.cops.R
@@ -32,7 +32,7 @@ process.cops <- function(dirdat, ASCII=FALSE, CLEAN.FILES=FALSE) {
 	info.file <- paste(dirdat, "info.cops.dat", sep = "/")
 	if(!file.exists(info.file)) {
 		file.copy(from = header.info.file, to = info.file)
-		files.in.dirdat <- list.files(dirdat)
+		files.in.dirdat <- list.files(dirdat, pattern = "URC")
 		files.in.dirdat <- files.in.dirdat[! files.in.dirdat %in% c("init.cops.dat", "info.cops.dat")]
 		lines.in.info.file <- paste(files.in.dirdat, "NA", "NA", "999", "x", "x", "x","x", sep = ";")
 		write(file = info.file, lines.in.info.file, append = TRUE, ncolumns = 1)

--- a/data/info.header.dat
+++ b/data/info.header.dat
@@ -8,7 +8,7 @@
 # field #1 : file name                                                                                                                #
 # field #2 : longitude (decimal degs)                                                                                                 #
 # field #3 : latitude (decimal degs)                                                                                                  #
-# field #4 : a positive value, 0, 999, or NA                                                                                               #
+# field #4 : a positive value, 0, 999, or NA                                                                                          #
 #           if > 0, it is the chlorophyll concentration and is used to calculate absorption at each wavelength (case 1 waters model)  #
 #           if = 0, the absorption coefficients for all wavelengths must be found in a file called absorption.cops.dat                #
 #           If 999, the absorption coefficients are derived from Kd near the sea surface
@@ -19,10 +19,10 @@
 # NB : fields 5 6 7 8 are defined for the whole cast in file init.cops.dat                                                            #
 #      if no peculiar value is needed for an experiment, just put a "x" in the field, the value in init.cops.dat is kept              #
 #-------------------------                                                                                                            #
-# field #5 : time.window, 2 numeric values separated by ","; no space                                                                 #
-# field #6 : sub.surface.removed.layer, N numeric separated by ","; no space (N is the number of optics instruments - respect order)   #
-# field #7 : tiltmax, N numeric separated by ","; no space (N is the number of optics instruments - respect order)                     #
-# field #8 : time.interval.for.smoothing, N numeric separated by ","; no space (N is the number of optics instruments - respect order)#
+# field #5: time.window, 2 numeric values separated by ","; no space                                                                  #
+# field #6: sub.surface.removed.layer, N numeric separated by ","; no space (N is the number of optics instruments - respect order)   #
+# field #7: tiltmax, N numeric separated by ","; no space (N is the number of optics instruments - respect order)                     #
+# field #8: depth.interval.for.smoothing, N numeric separated by ","; no space (N is the number of optics instruments - respect order)#
 #                                                                                                                                     #
 #######################################################################################################################################
 # 4 optional fields ( #9 #10 #11 and #12 ) : names of files containing dark measures                                                  #


### PR DESCRIPTION
Minor change for information consistence in info file.

Also use `list.file(dirdat, pattern= "URC")` to get only casts in info.file. 
Could be made more generic for compatibility with all kind of casts names recorded over the year.
something like :
`"(?<=CAST_)[:digit:]{3}_[:digit:]{6}_[:digit:]{6}_(URC|URU)(?=\.)"`